### PR TITLE
Release 0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.7] - 2024-04-14
+### Changes
+- Added new config section "accounts" to configure custom "LOGON_ACCOUNT_INDEX" and "RECONCILE_ACCOUNT_INDEX". This is
+  moved from the 'custom' section in release 0.1.1.
+
 ## [0.1.6] - 2024-03-14
 ### Bugfixes
 - add keep_cookies to serialized aim fields
@@ -34,7 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.1] - 2024-02-03
 ### Changes
 - Add "get_safe_details" method
-- Add support for "custom" configs to override the default logon and reconcile account index
+- Add support for "custom" configs to override the default logon and reconcile account index. 
+  **DO NOT USE, deprecated in 0.1.7**.
 - Add support to retain cookies during login, and use for subsequent API calls for load-balanced PVWAs.
 
 ## [0.1.0] - 2024-01-26

--- a/aiobastion/accounts.py
+++ b/aiobastion/accounts.py
@@ -397,7 +397,7 @@ class Account:
         """
         | This function unlinks the reconciliation account of the given account (or the list of accounts)
         | ⚠️ The "reconcile" Account is supposed to have an index of 3
-        | You can change it by setting custom:RECONCILE_ACCOUNT_INDEX in your config file
+        | You can change it by setting accounts:RECONCILE_ACCOUNT_INDEX in your config file
 
 
         :param account: a PrivilegedAccount object or a list of PrivilegedAccount objects
@@ -411,7 +411,7 @@ class Account:
         """
         | This function unlinks the logon account of the given account (or the list of accounts)
         | ⚠️ The "logon" Account index is default to 2 but can be set differently on the platform
-        | You can change it by setting custom:LOGON_ACCOUNT_INDEX in your config file
+        | You can change it by setting accounts:LOGON_ACCOUNT_INDEX in your config file
 
         :param account: a PrivilegedAccount object or a list of PrivilegedAccount objects
         :type account: PrivilegedAccount, list

--- a/aiobastion/config.py
+++ b/aiobastion/config.py
@@ -39,6 +39,9 @@ class Config:
         self.PVWA_CA = Config.CYBERARK_DEFAULT_VERIFY
         self.keep_cookies = False
 
+        # Accounts section Initialisation
+        self.accounts = None
+
         with open(configfile, 'r') as config:
             configuration = yaml.safe_load(config)
 
@@ -47,7 +50,7 @@ class Config:
             keyname = k.lower()
 
             if keyname not in ["aim", "connection", "cpm", "custom",
-                               "customipfield", "label", "pvwa", "retention"]:
+                               "customipfield", "label", "pvwa", "retention", "accounts"]:
                 warnings.warn(f"aiobastion - Unknown section '{k}' in {self.configfile}")
                 continue
 
@@ -75,6 +78,8 @@ class Config:
             self.customIPField = configuration["customipfield"]
         if "retention" in configuration:
             self.retention = self._to_integer("retention", configuration["retention"])
+        if "accounts" in configuration:
+            self.accounts = configuration["accounts"]
 
     def _read_section_connection(self, configuration):
         for k in list(configuration.keys()):

--- a/aiobastion/cyberark.py
+++ b/aiobastion/cyberark.py
@@ -90,10 +90,10 @@ class EPV:
         self.system_health = SystemHealth(self)
         self.utils = Utilities(self)
 
-    def _epv_set_linked_account_index(self, custom):
-        if custom is not None:
-            if custom['LOGON_ACCOUNT_INDEX']: self.LOGON_ACCOUNT_INDEX = int(custom['LOGON_ACCOUNT_INDEX']) # noqa:
-            if custom['RECONCILE_ACCOUNT_INDEX']: self.RECONCILE_ACCOUNT_INDEX = int(custom['RECONCILE_ACCOUNT_INDEX']) # noqa:
+    def _epv_set_linked_account_index(self, accounts):
+        if accounts is not None:
+            if accounts['LOGON_ACCOUNT_INDEX']: self.LOGON_ACCOUNT_INDEX = int(accounts['LOGON_ACCOUNT_INDEX']) # noqa:
+            if accounts['RECONCILE_ACCOUNT_INDEX']: self.RECONCILE_ACCOUNT_INDEX = int(accounts['RECONCILE_ACCOUNT_INDEX']) # noqa:
 
     def _epv_config(self, configfile):
         self.config = Config(configfile)
@@ -113,8 +113,9 @@ class EPV:
         # Other definition
         self.cpm = self.config.CPM
         self.retention = self.config.retention
+        self.accounts = self.config.accounts
 
-        self._epv_set_linked_account_index(self.config.custom)
+        self._epv_set_linked_account_index(self.config.accounts)
 
     def _epv_serialize(self, serialized):
         if not isinstance(serialized, dict):
@@ -134,6 +135,7 @@ class EPV:
                 "keep_cookies",
                 "verify",
                 "custom",
+                "accounts",
             ]:
                 raise AiobastionException(f"Unknown serialized field: {k} = {serialized[k]!r}")
 
@@ -154,7 +156,9 @@ class EPV:
             self.__token = serialized['token']
         if "custom" in serialized:
             self.custom = serialized['custom']
-            self._epv_set_linked_account_index(self.custom)
+        if "accounts" in serialized:
+            self.accounts = serialized['accounts']
+            self._epv_set_linked_account_index(self.accounts)
 
         # AIM Communication
         if "AIM" in serialized:

--- a/docs/accounts.rst
+++ b/docs/accounts.rst
@@ -44,7 +44,7 @@ it has the following methods :
 About linked account index :
     * reconcile account index: 3 - you should NOT change it unless your system has different custom value.
     * logon account index: 2 - this is different from the installation (1). The default value is kept at 2 to avoid
-      breaking existing users. You can override it to 1 by providing a "custom.LOGON_ACCOUNT_INDEX" value in your config.
+      breaking existing users. You can override it to 1 by providing a "accounts.LOGON_ACCOUNT_INDEX" value in your config.
 
 Calling functions
 -------------------

--- a/docs/login.rst
+++ b/docs/login.rst
@@ -432,6 +432,9 @@ The configuration file contains the following main sections:
 +---------------+-----------+----------------------------------------------------------------------------------------------------------------------+
 | retention     | Optional  | For safe creation, the number of retained versions of every password that is stored in the Safe (EPV.retention).     +
 +---------------+-----------+----------------------------------------------------------------------------------------------------------------------+
+| accounts      | Optional  | To override the reconcile and logon account index                                                                    +
++---------------+-----------+----------------------------------------------------------------------------------------------------------------------+
+
 
 CONNECTION section / field definitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -530,6 +533,16 @@ AIM section / field definitions
 | keep_cookies         | Optional                | Keep cookies from login and send in subsequent API calls (default Fasle). You may need to  +
 |                      |                         | You may need to set to True when a load-balancer is present.                               |
 +----------------------+-------------------------+--------------------------------------------------------------------------------------------+
+
+Accounts Section
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
++-------------------------+-------------------------+-----------------------------------------------------------------------------------------+
+| Field                   | Type                    | Description                                                                             +
++=========================+=========================+=========================================================================================+
+| LOGON_ACCOUNT_INDEX     | Optional                | The logon account index (default to 1) -- you most time should leave it alone           +
++-------------------------+-------------------------+-----------------------------------------------------------------------------------------+
+| RECONCILE_ACCOUNT_INDEX | Optional                | The reconcile account index (default to 2) -- often you need to override with 3         +
++-------------------------+-------------------------+-----------------------------------------------------------------------------------------+
 
 
 A complete configuration file definition

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ class TestEPV(IsolatedAsyncioTestCase):
     @classmethod
     def setUpClass(cls):
         cls.custom_linked_acounts = {
-            "custom": {
+            "accounts": {
                 "RECONCILE_ACCOUNT_INDEX": 1,
                 "LOGON_ACCOUNT_INDEX": 3
             }

--- a/tests/test_data/custom_config.yml
+++ b/tests/test_data/custom_config.yml
@@ -2,7 +2,7 @@ connection:
   authtype: cyberark
   password: abc
   username: def
-custom:
+accounts:
   LOGON_ACCOUNT_INDEX: 3
   RECONCILE_ACCOUNT_INDEX: 1
 label: Production Demo


### PR DESCRIPTION
Moved "LOGON_ACCOUNT_INDEX" and "RECONCILE_ACCOUNT_INDEX" from "custom" config section to newly created, "accounts" section.

Tested against haproxy and F5 load balancers.